### PR TITLE
Change dir "scripts" into "compiler" in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,8 +116,8 @@ setuptools.setup(
     distclass=binaryDist,
     entry_points={
         'console_scripts': [
-            'onnx-cpp = deepC.scripts.onnx2cpp:main',
-            'compile-onnx = deepC.scripts.onnx2exe:main',
+            'onnx-cpp = deepC.compiler.onnx2cpp:main',
+            'compile-onnx = deepC.compiler.onnx2exe:main',
         ]
     },
     dependency_links=[]


### PR DESCRIPTION
It seems that the previous "scripts" directory is now named "compiler" in `head`. This pull request fixes the corresponding paths in setup.py.