### PR TITLE
Fix entry point directory

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ import os,sys
 DNNC_ROOT=os.path.abspath(os.path.dirname(__file__))
 sys.path.append(DNNC_ROOT)
 sys.path.append(DNNC_ROOT+os.path.sep+'deepC')
-sys.path.append(DNNC_ROOT+os.path.sep+'scripts')
+sys.path.append(DNNC_ROOT+os.path.sep+'compiler')
 
 #from swig import dnnc
 #from python import read_onnx

--- a/setup.py
+++ b/setup.py
@@ -116,8 +116,8 @@ setuptools.setup(
     distclass=binaryDist,
     entry_points={
         'console_scripts': [
-            'onnx-cpp = deepC.scripts.onnx2cpp:main',
-            'compile-onnx = deepC.scripts.onnx2exe:main',
+            'onnx-cpp = deepC.compiler.onnx2cpp:main',
+            'compile-onnx = deepC.compiler.onnx2exe:main',
         ]
     },
     dependency_links=[]


### PR DESCRIPTION
Path to onnx-cpp has been changed from "scripts" to "compiler" directory - yet setup.py and __init__.py still refered to the old path. This pull request provides a fix.